### PR TITLE
fix: include bot search results and preserve authors

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -266,10 +266,19 @@ type Edited struct {
 	TS   string `json:"ts"`
 }
 
+// BotProfile identifies the app/bot author of a message.
+type BotProfile struct {
+	Name string `json:"name"`
+}
+
 // Message represents a Slack message
 type Message struct {
 	Type        string       `json:"type"`
 	User        string       `json:"user"`
+	Username    string       `json:"username,omitempty"`
+	BotProfile  BotProfile   `json:"bot_profile,omitempty"`
+	BotID       string       `json:"bot_id,omitempty"`
+	AppID       string       `json:"app_id,omitempty"`
 	Text        string       `json:"text"`
 	TS          string       `json:"ts"`
 	ThreadTS    string       `json:"thread_ts,omitempty"`
@@ -1039,7 +1048,7 @@ func (c *Client) DownloadFile(downloadURL string, w io.Writer) error {
 // --- Search Methods (require user token) ---
 
 // SearchMessages searches for messages matching a query
-func (c *Client) SearchMessages(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
+func (c *Client) SearchMessages(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -1049,10 +1058,6 @@ func (c *Client) SearchMessages(query string, count, page int, sort, sortDir str
 	if highlight {
 		params.Set("highlight", "true")
 	}
-	if includeBots {
-		params.Set("search_exclude_bots", "false")
-	}
-
 	body, err := c.get("search.messages", params)
 	if err != nil {
 		return nil, err
@@ -1067,7 +1072,7 @@ func (c *Client) SearchMessages(query string, count, page int, sort, sortDir str
 }
 
 // SearchFiles searches for files matching a query
-func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
+func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -1077,10 +1082,6 @@ func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string
 	if highlight {
 		params.Set("highlight", "true")
 	}
-	if includeBots {
-		params.Set("search_exclude_bots", "false")
-	}
-
 	body, err := c.get("search.files", params)
 	if err != nil {
 		return nil, err
@@ -1095,7 +1096,7 @@ func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string
 }
 
 // SearchAll searches for both messages and files matching a query
-func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
+func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -1105,10 +1106,6 @@ func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, 
 	if highlight {
 		params.Set("highlight", "true")
 	}
-	if includeBots {
-		params.Set("search_exclude_bots", "false")
-	}
-
 	body, err := c.get("search.all", params)
 	if err != nil {
 		return nil, err

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1209,7 +1209,7 @@ func TestClient_SearchMessages_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchMessages("test query", 20, 1, "score", "desc", false, false)
+	result, err := client.SearchMessages("test query", 20, 1, "score", "desc", false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1251,7 +1251,7 @@ func TestClient_SearchMessages_WithHighlight(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	_, err := client.SearchMessages("test", 20, 1, "score", "desc", true, false)
+	_, err := client.SearchMessages("test", 20, 1, "score", "desc", true)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1270,13 +1270,66 @@ func TestClient_SearchMessages_APIError(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	_, err := client.SearchMessages("test", 20, 1, "score", "desc", false, false)
+	_, err := client.SearchMessages("test", 20, 1, "score", "desc", false)
 
 	if err == nil {
 		t.Error("expected error for API failure")
 	}
 	if !strings.Contains(err.Error(), "not_authed") {
 		t.Errorf("expected error to contain 'not_authed', got %s", err.Error())
+	}
+}
+
+func TestClient_SearchOmitsBotFilterParameter(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		search   func(*Client) error
+	}{
+		{
+			name:     "messages",
+			endpoint: "/search.messages",
+			search: func(c *Client) error {
+				_, err := c.SearchMessages("test", 20, 1, "score", "desc", false)
+				return err
+			},
+		},
+		{
+			name:     "files",
+			endpoint: "/search.files",
+			search: func(c *Client) error {
+				_, err := c.SearchFiles("test", 20, 1, "score", "desc", false)
+				return err
+			},
+		},
+		{
+			name:     "all",
+			endpoint: "/search.all",
+			search: func(c *Client) error {
+				_, err := c.SearchAll("test", 20, 1, "score", "desc", false)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != tt.endpoint {
+					t.Errorf("path = %q, want %q", r.URL.Path, tt.endpoint)
+				}
+				if r.URL.Query().Has("search_exclude_bots") {
+					t.Error("search_exclude_bots should be omitted")
+				}
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+			}))
+			defer server.Close()
+
+			c := NewWithConfig(server.URL, "test-token", nil)
+			if err := tt.search(c); err != nil {
+				t.Fatalf("search: %v", err)
+			}
+		})
 	}
 }
 
@@ -1315,7 +1368,7 @@ func TestClient_SearchFiles_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchFiles("document", 20, 1, "score", "desc", false, false)
+	result, err := client.SearchFiles("document", 20, 1, "score", "desc", false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1389,7 +1442,7 @@ func TestClient_SearchAll_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchAll("report", 20, 1, "timestamp", "asc", false, false)
+	result, err := client.SearchAll("report", 20, 1, "timestamp", "asc", false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -64,7 +64,7 @@ func runHistory(channel string, opts *historyOptions, c *client.Client) error {
 		// blocks-vs-text distinction doesn't matter here.
 		body, _ := messageBody(m, resolver)
 		text := truncate(body, 80)
-		name := resolver.Resolve(m.User)
+		name := messageAuthor(m, resolver)
 		edited := ""
 		if m.Edited != nil {
 			edited = " [edited]"

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -81,6 +81,18 @@ func messageBody(m client.Message, resolver *client.UserResolver) (body string, 
 	return rendered.Body, rendered.PreserveNewlines
 }
 
+func messageAuthor(m client.Message, resolver *client.UserResolver) string {
+	if m.User != "" {
+		return resolver.Resolve(m.User)
+	}
+	for _, name := range []string{m.Username, m.BotProfile.Name, m.BotID, m.AppID} {
+		if name != "" {
+			return name
+		}
+	}
+	return "bot"
+}
+
 // indentContinuation replaces interior newlines with "\n\t" so that every
 // line after the first is indented under the "[<ts>] <user>:" header.
 // Any trailing newline is trimmed first to avoid a dangling tab.

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1711,6 +1711,50 @@ func TestMessageBody_NilResolverTextPath(t *testing.T) {
 	assert.Equal(t, "hello <@U123>", body)
 }
 
+func TestMessageAuthorFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		message client.Message
+		want    string
+	}{
+		{"user", client.Message{User: "U123", Username: "ignored"}, "U123"},
+		{"username", client.Message{Username: "deploy-bot", BotProfile: client.BotProfile{Name: "ignored"}}, "deploy-bot"},
+		{"bot profile", client.Message{BotProfile: client.BotProfile{Name: "deploy-bot"}, BotID: "B123"}, "deploy-bot"},
+		{"bot id", client.Message{BotID: "B123", AppID: "A123"}, "B123"},
+		{"app id", client.Message{AppID: "A123"}, "A123"},
+		{"stable fallback", client.Message{}, "bot"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, messageAuthor(tt.message, nil))
+		})
+	}
+}
+
+func TestRunHistory_BotAuthorAndBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"messages": []map[string]interface{}{{
+				"type": "message", "subtype": "bot_message", "ts": "1234567890.123456",
+				"username": "deploy-bot", "bot_id": "B123", "app_id": "A123",
+				"bot_profile": map[string]interface{}{"name": "deploy-bot"},
+				"blocks": []map[string]interface{}{{
+					"type": "section", "text": map[string]interface{}{"type": "mrkdwn", "text": "deployment complete"},
+				}},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", &historyOptions{limit: 20}, c))
+	})
+	assert.Contains(t, out, "deploy-bot: deployment complete")
+}
+
 func TestHumanSize(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1759,6 +1759,17 @@ func TestRunHistory_BotAuthorAndBody(t *testing.T) {
 	assert.Contains(t, out, "deploy-bot: deployment complete")
 }
 
+func TestRenderMessageList_BotAuthorAndBody(t *testing.T) {
+	out := captureTextOutput(t, func() {
+		renderMessageList([]client.Message{{
+			TS:         "1234567890.123456",
+			BotProfile: client.BotProfile{Name: "deploy-bot"},
+			Text:       "deployment complete",
+		}}, nil)
+	})
+	assert.Contains(t, out, "deploy-bot: deployment complete")
+}
+
 func TestHumanSize(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1712,12 +1712,16 @@ func TestMessageBody_NilResolverTextPath(t *testing.T) {
 }
 
 func TestMessageAuthorFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(mockUserInfoHandler))
+	defer server.Close()
+	resolver := client.NewUserResolver(client.NewWithConfig(server.URL, "test-token", nil))
+	assert.Equal(t, "alice", messageAuthor(client.Message{User: "U001", Username: "ignored"}, resolver))
+
 	tests := []struct {
 		name    string
 		message client.Message
 		want    string
 	}{
-		{"user", client.Message{User: "U123", Username: "ignored"}, "U123"},
 		{"username", client.Message{Username: "deploy-bot", BotProfile: client.BotProfile{Name: "ignored"}}, "deploy-bot"},
 		{"bot profile", client.Message{BotProfile: client.BotProfile{Name: "deploy-bot"}, BotID: "B123"}, "deploy-bot"},
 		{"bot id", client.Message{BotID: "B123", AppID: "A123"}, "B123"},

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -78,7 +78,7 @@ func renderMessageList(messages []client.Message, resolver *client.UserResolver)
 		} else {
 			text = flatten(body)
 		}
-		name := resolver.Resolve(m.User)
+		name := messageAuthor(m, resolver)
 		edited := ""
 		if m.Edited != nil {
 			edited = " [edited]"

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -21,7 +21,6 @@ type allOptions struct {
 	before      string
 	hasLink     bool
 	hasReaction bool
-	includeBots bool
 }
 
 func newAllCmd() *cobra.Command {
@@ -68,8 +67,6 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Content before date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&opts.hasLink, "has-link", false, "Content containing links")
 	cmd.Flags().BoolVar(&opts.hasReaction, "has-reaction", false, "Content with reactions")
-	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
-
 	return cmd
 }
 
@@ -102,7 +99,7 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchAll(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
+	result, err := c.SearchAll(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -10,19 +10,18 @@ import (
 )
 
 type filesOptions struct {
-	count       int
-	page        int
-	sort        string
-	sortDir     string
-	highlight   bool
-	scope       string
-	inChannel   string
-	fromUser    string
-	after       string
-	before      string
-	fileType    string
-	hasPin      bool
-	includeBots bool
+	count     int
+	page      int
+	sort      string
+	sortDir   string
+	highlight bool
+	scope     string
+	inChannel string
+	fromUser  string
+	after     string
+	before    string
+	fileType  string
+	hasPin    bool
 }
 
 func newFilesCmd() *cobra.Command {
@@ -68,8 +67,6 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Files before date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&opts.fileType, "type", "", "Filter by file type (pdf, doc, image, etc.)")
 	cmd.Flags().BoolVar(&opts.hasPin, "has-pin", false, "Files that are pinned")
-	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
-
 	return cmd
 }
 
@@ -102,7 +99,7 @@ func runSearchFiles(query string, opts *filesOptions, c *client.Client) error {
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchFiles(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
+	result, err := c.SearchFiles(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -26,7 +26,6 @@ type messagesOptions struct {
 	before      string
 	hasLink     bool
 	hasReaction bool
-	includeBots bool
 }
 
 func newMessagesCmd() *cobra.Command {
@@ -54,8 +53,7 @@ Examples:
   slck search messages "project update" --from "@alice"
   slck search messages "deployment" --after 2025-01-01
   slck search messages "test" --scope public
-  slck search messages "meeting" --has-link --has-reaction
-  slck search messages "alert" --include-bots`,
+  slck search messages "meeting" --has-link --has-reaction`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearchMessages(args[0], opts, nil)
@@ -76,8 +74,6 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Messages before date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&opts.hasLink, "has-link", false, "Messages containing links")
 	cmd.Flags().BoolVar(&opts.hasReaction, "has-reaction", false, "Messages with reactions")
-	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
-
 	return cmd
 }
 
@@ -110,7 +106,7 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchMessages(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
+	result, err := c.SearchMessages(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
 	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
@@ -846,67 +849,42 @@ func TestSearchMessages_WithHighlight(t *testing.T) {
 	}
 }
 
-func TestSearchMessages_WithIncludeBots(t *testing.T) {
-	response := map[string]interface{}{
-		"ok": true,
-		"messages": map[string]interface{}{
-			"total":   0,
-			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
-			"matches": []map[string]interface{}{},
-		},
-	}
-
+func TestSearchMessages_IncludesBotsByDefault(t *testing.T) {
 	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("search_exclude_bots") != "false" {
-			t.Errorf("expected search_exclude_bots=false, got %s", r.URL.Query().Get("search_exclude_bots"))
+		matches := []map[string]interface{}{{
+			"type": "message", "channel": map[string]string{"id": "C1", "name": "general"},
+			"user": "U1", "username": "alice", "text": "human message", "ts": "1.0",
+		}}
+		if r.URL.Query().Has("search_exclude_bots") {
+			t.Error("search_exclude_bots should be omitted")
 		}
-		json.NewEncoder(w).Encode(response)
+		matches = append(matches, map[string]interface{}{
+			"type": "message", "channel": map[string]string{"id": "C1", "name": "general"},
+			"username": "deploy-bot", "text": "bot message", "ts": "2.0",
+		})
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"messages": map[string]interface{}{
+				"total": len(matches), "paging": map[string]int{"count": 20, "total": len(matches), "page": 1, "pages": 1}, "matches": matches,
+			},
+		})
 	})
 	defer server.Close()
 
-	opts := &messagesOptions{
-		count:       20,
-		page:        1,
-		sort:        "score",
-		sortDir:     "desc",
-		includeBots: true,
-	}
-
-	err := runSearchMessages("bot-alert", opts, c)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	base := messagesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}
+	out := captureOutput(t, func() { require.NoError(t, runSearchMessages("test", &base, c)) })
+	assert.Contains(t, out, "alice")
+	assert.Contains(t, out, "deploy-bot")
 }
 
-func TestSearchMessages_WithoutIncludeBots(t *testing.T) {
-	response := map[string]interface{}{
-		"ok": true,
-		"messages": map[string]interface{}{
-			"total":   0,
-			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
-			"matches": []map[string]interface{}{},
-		},
-	}
-
-	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("search_exclude_bots") != "" {
-			t.Errorf("expected search_exclude_bots to be absent, got %s", r.URL.Query().Get("search_exclude_bots"))
-		}
-		json.NewEncoder(w).Encode(response)
-	})
-	defer server.Close()
-
-	opts := &messagesOptions{
-		count:       20,
-		page:        1,
-		sort:        "score",
-		sortDir:     "desc",
-		includeBots: false,
-	}
-
-	err := runSearchMessages("test", opts, c)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+func TestContentSearchBotFlags(t *testing.T) {
+	for _, name := range []string{"messages", "files", "all"} {
+		t.Run(name, func(t *testing.T) {
+			cmd, _, err := NewCmd().Find([]string{name})
+			require.NoError(t, err)
+			assert.Nil(t, cmd.Flags().Lookup("exclude-bots"))
+			assert.Nil(t, cmd.Flags().Lookup("include-bots"))
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- use Slack's bot-inclusive default for message, file, and combined content search
- remove the ineffective content-search `--include-bots` flag and its client boolean without adding a replacement filter
- preserve bot/app authors across history, thread, and read with one shared fallback path
- leave the separate `users search --include-bots` behavior unchanged

## Validation

- `make test`
- `make lint`
- focused tests: 503 passed across the client, search, and messages packages

## Sanitized empirical results

- Default search in a mixed channel returned 484 results. Its first 100 rows contained 95 bot/app rows and 5 human rows.
- Omitted and plausible bot-exclusion parameter variants returned the same totals and author distribution; Slack's documented content-search API exposes no bot-filter argument.
- A 20-message history sample had 0 blank authors and 0 blank bodies; 18 rows resolved to the expected app name.
- Reading a selected app message resolved to the same recognizable app name and a non-empty body.

Closes #196
