### PR TITLE
feat(unreads): add unread conversations command

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ or `op read ... | slck set-credential --key bot_token --stdin`.
    <details>
    <summary><strong>Extended manifest</strong> — every read scope slck can use, plus all writes (DMs, group DMs, file uploads, canvas CRUD, etc.)</summary>
 
-   Use this if you want maximum capability out of the box — reading DMs and group DMs, uploading file attachments to any channel/DM/group-DM, creating/editing/deleting canvases, resolving `@subteam` mentions, extended user profile data, etc. Every scope here is either needed by an existing slck command or unlocks a capability that commonly extends one (e.g. `im:history` so `slck messages thread` works on DMs, `files:write` for `slck messages send --file`, `canvases:write` for `slck canvas create`).
+   Use this if you want maximum capability out of the box — writing to DMs and group DMs, uploading file attachments to any channel/DM/group-DM, creating/editing/deleting canvases, resolving `@subteam` mentions, extended user profile data, etc. Every scope here is either needed by an existing slck command or unlocks a capability that commonly extends one (e.g. `im:write` to send DMs, `files:write` for `slck messages send --file`, `canvases:write` for `slck canvas create`).
 
    ```json
    {
@@ -383,7 +383,7 @@ or `op read ... | slck set-credential --key bot_token --stdin`.
 Your token is stored in the OS keyring (Keychain / Credential Manager /
 Secret Service). It is never written to a plaintext file.
 
-**NOTE:** The default manifest keeps the user token search-only. To run other commands with `--as-user`, use the extended manifest above; it includes the supported user equivalents for every current `slck` operation.
+**NOTE:** The default manifest gives the user token search access plus the conversation, history, and user read scopes required by `slck unreads`. To run write commands or other commands with `--as-user`, use the extended manifest above; it includes the supported user equivalents for every current `slck` operation.
 
 ### Scripted / non-interactive setup
 
@@ -426,6 +426,8 @@ The manifest above includes these scopes:
 | `files:read` | Download files, get file info |
 | `groups:read` | List private channels |
 | `groups:history` | Read message history from private channels |
+| `im:read` / `im:history` | List and read direct messages (user token) |
+| `mpim:read` / `mpim:history` | List and read multi-person direct messages (user token) |
 | `reactions:write` | Add/remove reactions |
 | `team:read` | Get workspace info |
 | `users:read` | List users, get user info |
@@ -435,8 +437,8 @@ The **extended manifest** (see the collapsible section above) adds these capabil
 
 | Scope | Unlocks |
 |-------|---------|
-| `im:history` / `im:read` / `im:write` | Read messages in DMs, list DMs, open new DMs to post to |
-| `mpim:history` / `mpim:read` / `mpim:write` | Same for multi-person DMs (group DMs) |
+| `im:write` | Open new DMs to post to |
+| `mpim:write` | Open new multi-person DMs (group DMs) to post to |
 | `files:write` | Upload files — `slck messages send --file` in any channel/DM/group-DM |
 | `canvases:write` | Create, edit, delete canvases — `slck canvas create/edit/delete` |
 | `groups:write` | Create/archive private channels |
@@ -533,7 +535,7 @@ slck unreads list --exclude-dms
 slck unreads list --exclude-channels
 ```
 
-This command reconstructs unread conversations from Slack's conversation membership and sidebar-priority data through supported APIs. Large workspaces may take a few minutes because Slack requires per-conversation checks. Slack does not expose custom sidebar sections, exact sidebar ordering, or channel badge counts.
+This command reconstructs unread conversations from Slack's conversation membership and read state through supported APIs. Large workspaces may take a few minutes because Slack requires per-conversation checks. Slack does not expose custom sidebar sections, exact sidebar ordering, or channel badge counts.
 
 | Command | Flags | Description |
 |---------|-------|-------------|

--- a/README.md
+++ b/README.md
@@ -193,7 +193,16 @@ or `op read ... | slck set-credential --key bot_token --stdin`.
            "users:read"
          ],
          "user": [
-           "search:read"
+           "channels:history",
+           "channels:read",
+           "groups:history",
+           "groups:read",
+           "im:history",
+           "im:read",
+           "mpim:history",
+           "mpim:read",
+           "search:read",
+           "users:read"
          ]
        }
      },
@@ -229,7 +238,16 @@ or `op read ... | slck set-credential --key bot_token --stdin`.
          - "team:read"
          - "users:read"
        user:
+         - "channels:history"
+         - "channels:read"
+         - "groups:history"
+         - "groups:read"
+         - "im:history"
+         - "im:read"
+         - "mpim:history"
+         - "mpim:read"
          - "search:read"
+         - "users:read"
    settings:
      org_deploy_enabled: false
      socket_mode_enabled: false
@@ -437,9 +455,9 @@ This CLI supports two types of Slack tokens:
 | Token Type | Prefix | Commands | How to Get |
 |------------|--------|----------|------------|
 | Bot token | `xoxb-` | channels, users, messages, workspace | OAuth & Permissions → Bot User OAuth Token |
-| User token | `xoxp-` | search; any command run with `--as-user` when the matching user scopes are granted | OAuth & Permissions → User OAuth Token |
+| User token | `xoxp-` | search, unreads; any command run with `--as-user` when the matching user scopes are granted | OAuth & Permissions → User OAuth Token |
 
-Most commands use the **bot token**. Search commands require a **user token**.
+Most commands use the **bot token**. Search and unreads commands require a **user token**.
 
 **Setting up both tokens:**
 
@@ -447,7 +465,7 @@ Most commands use the **bot token**. Search commands require a **user token**.
 # Bot token (for channels, users, messages, workspace)
 op read 'op://Personal/slck/bot_token'  | slck set-credential --key bot_token  --stdin
 
-# User token (for search)
+# User token (for search and unreads)
 op read 'op://Personal/slck/user_token' | slck set-credential --key user_token --stdin
 ```
 
@@ -456,7 +474,7 @@ Or run `slck init` for a guided, interactive setup of both.
 **Getting a user token:**
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) → Your app
-2. OAuth & Permissions → User Token Scopes → Add `search:read`
+2. OAuth & Permissions → User Token Scopes → add the user scopes from the manifest above
 3. Reinstall app to workspace (if already installed)
 4. Copy the **User OAuth Token** (starts with `xoxp-`)
 
@@ -500,6 +518,26 @@ slck messages send --as-bot C1234567890 "Uses bot token"
 ```
 
 ## Usage
+
+### Unreads
+
+```bash
+# Unread channels and human DMs
+slck unreads list
+
+# Include DMs with agents and apps
+slck unreads list --include-apps
+
+# Show only one conversation class
+slck unreads list --exclude-dms
+slck unreads list --exclude-channels
+```
+
+This command reconstructs unread conversations from Slack's conversation membership and sidebar-priority data through supported APIs. Large workspaces may take a few minutes because Slack requires per-conversation checks. Slack does not expose custom sidebar sections, exact sidebar ordering, or channel badge counts.
+
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `list` | `--include-apps`, `--exclude-channels`, `--exclude-dms` | List unread conversations |
 
 ### Channels
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Or run `slck init` for a guided, interactive setup of both.
 3. Reinstall app to workspace (if already installed)
 4. Copy the **User OAuth Token** (starts with `xoxp-`)
 
-For broad `--as-user` access instead of search-only access, apply the extended manifest above before reinstalling.
+For broad `--as-user` access beyond search and unreads, apply the extended manifest above before reinstalling.
 
 **Setup-time env-var ingress** (read once during `slck init`, never at runtime):
 
@@ -504,7 +504,7 @@ These flags are available on all commands:
 
 ### Choosing Between Bot and User Tokens
 
-By default, all commands other than search use your bot token. You can set the `SLCK_AS_USER` env var to `true` to make your user token the default. You can also use flags to specify which token to use for any specific command (and this will override the default behavior set by your env var).
+By default, all commands other than search and unreads use your bot token. You can set the `SLCK_AS_USER` env var to `true` to make your user token the default. You can also use flags to specify which token to use for any specific command (and this will override the default behavior set by your env var).
 
 ```bash
 # Send a message as yourself (using user token)
@@ -527,7 +527,7 @@ slck messages send --as-bot C1234567890 "Uses bot token"
 # Unread channels and human DMs
 slck unreads list
 
-# Include DMs with agents and apps
+# Include DMs with agents and apps, even with --exclude-dms
 slck unreads list --include-apps
 
 # Show only one conversation class

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,7 +14,10 @@ import (
 	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
 )
 
-const defaultBaseURL = "https://slack.com/api"
+const (
+	defaultBaseURL         = "https://slack.com/api"
+	maxRateLimitGetRetries = 3
+)
 
 // useUserToken stores which token to use, set by root command
 // nil = not explicitly set (check environment variable)
@@ -126,7 +129,7 @@ func (c *Client) get(endpoint string, params url.Values) (result []byte, err err
 		reqURL += "?" + params.Encode()
 	}
 
-	for {
+	for retries := 0; ; retries++ {
 		req, err := http.NewRequest("GET", reqURL, nil)
 		if err != nil {
 			return nil, err
@@ -143,6 +146,9 @@ func (c *Client) get(endpoint string, params url.Values) (result []byte, err err
 			retryAfter, parseErr := strconv.Atoi(resp.Header.Get("Retry-After"))
 			if parseErr != nil {
 				return nil, fmt.Errorf("slack API rate limited without a valid Retry-After header")
+			}
+			if retries == maxRateLimitGetRetries {
+				return nil, fmt.Errorf("slack API rate limit retries exhausted after %d retries", maxRateLimitGetRetries)
 			}
 			time.Sleep(time.Duration(retryAfter) * time.Second)
 			continue

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -214,16 +214,15 @@ func (c *Client) post(endpoint string, data interface{}) (result []byte, err err
 
 // Channel represents a Slack channel
 type Channel struct {
-	ID          string  `json:"id"`
-	Name        string  `json:"name"`
-	IsPrivate   bool    `json:"is_private"`
-	IsArchived  bool    `json:"is_archived"`
-	IsIM        bool    `json:"is_im"`
-	IsMpIM      bool    `json:"is_mpim"`
-	User        string  `json:"user"`
-	LastRead    string  `json:"last_read"`
-	Priority    float64 `json:"priority"`
-	UnreadCount *int    `json:"unread_count"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	IsPrivate   bool   `json:"is_private"`
+	IsArchived  bool   `json:"is_archived"`
+	IsIM        bool   `json:"is_im"`
+	IsMpIM      bool   `json:"is_mpim"`
+	User        string `json:"user"`
+	LastRead    string `json:"last_read"`
+	UnreadCount *int   `json:"unread_count"`
 	Topic       struct {
 		Value string `json:"value"`
 	} `json:"topic"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
@@ -103,7 +104,7 @@ func NewUserClient() (*Client, error) {
 	defer func() { _ = st.Close() }()
 	token, err := st.UserToken()
 	if err != nil {
-		return nil, fmt.Errorf("user token required for search: %w", err)
+		return nil, fmt.Errorf("user token required: %w", err)
 	}
 
 	return &Client{
@@ -125,39 +126,47 @@ func (c *Client) get(endpoint string, params url.Values) (result []byte, err err
 		reqURL += "?" + params.Encode()
 	}
 
-	req, err := http.NewRequest("GET", reqURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Authorization", "Bearer "+c.token)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil && err == nil {
-			err = cerr
+	for {
+		req, err := http.NewRequest("GET", reqURL, nil)
+		if err != nil {
+			return nil, err
 		}
-	}()
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("Content-Type", "application/json")
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close()
+			retryAfter, parseErr := strconv.Atoi(resp.Header.Get("Retry-After"))
+			if parseErr != nil {
+				return nil, fmt.Errorf("slack API rate limited without a valid Retry-After header")
+			}
+			time.Sleep(time.Duration(retryAfter) * time.Second)
+			continue
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+
+		var slackResp SlackResponse
+		if err := json.Unmarshal(body, &slackResp); err != nil {
+			return nil, err
+		}
+		if !slackResp.OK {
+			return nil, fmt.Errorf("slack API error: %s", slackResp.Error)
+		}
+
+		return body, nil
 	}
-
-	var slackResp SlackResponse
-	if err := json.Unmarshal(body, &slackResp); err != nil {
-		return nil, err
-	}
-
-	if !slackResp.OK {
-		return nil, fmt.Errorf("slack API error: %s", slackResp.Error)
-	}
-
-	return body, nil
 }
 
 func (c *Client) post(endpoint string, data interface{}) (result []byte, err error) {
@@ -205,11 +214,17 @@ func (c *Client) post(endpoint string, data interface{}) (result []byte, err err
 
 // Channel represents a Slack channel
 type Channel struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	IsPrivate  bool   `json:"is_private"`
-	IsArchived bool   `json:"is_archived"`
-	Topic      struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	IsPrivate   bool    `json:"is_private"`
+	IsArchived  bool    `json:"is_archived"`
+	IsIM        bool    `json:"is_im"`
+	IsMpIM      bool    `json:"is_mpim"`
+	User        string  `json:"user"`
+	LastRead    string  `json:"last_read"`
+	Priority    float64 `json:"priority"`
+	UnreadCount *int    `json:"unread_count"`
+	Topic       struct {
 		Value string `json:"value"`
 	} `json:"topic"`
 	Purpose struct {
@@ -220,12 +235,13 @@ type Channel struct {
 
 // User represents a Slack user
 type User struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	RealName string `json:"real_name"`
-	IsAdmin  bool   `json:"is_admin"`
-	IsBot    bool   `json:"is_bot"`
-	Profile  struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	RealName  string `json:"real_name"`
+	IsAdmin   bool   `json:"is_admin"`
+	IsBot     bool   `json:"is_bot"`
+	IsAppUser bool   `json:"is_app_user"`
+	Profile   struct {
 		Email       string `json:"email"`
 		DisplayName string `json:"display_name"`
 		StatusText  string `json:"status_text"`
@@ -408,6 +424,44 @@ func (c *Client) ListChannels(types string, excludeArchived bool, limit int) ([]
 	}
 
 	return allChannels, nil
+}
+
+// ListUserConversations returns every conversation the token's user belongs to.
+func (c *Client) ListUserConversations() ([]Channel, error) {
+	var conversations []Channel
+	cursor := ""
+
+	for {
+		params := url.Values{
+			"exclude_archived": {"true"},
+			"limit":            {"200"},
+			"types":            {"public_channel,private_channel,im,mpim"},
+		}
+		if cursor != "" {
+			params.Set("cursor", cursor)
+		}
+
+		body, err := c.get("users.conversations", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var result struct {
+			Channels         []Channel `json:"channels"`
+			ResponseMetadata struct {
+				NextCursor string `json:"next_cursor"`
+			} `json:"response_metadata"`
+		}
+		if err := json.Unmarshal(body, &result); err != nil {
+			return nil, err
+		}
+
+		conversations = append(conversations, result.Channels...)
+		if result.ResponseMetadata.NextCursor == "" {
+			return conversations, nil
+		}
+		cursor = result.ResponseMetadata.NextCursor
+	}
 }
 
 // GetChannelInfo returns channel details

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -141,6 +141,26 @@ func TestClient_GetChannelInfo_RetriesRateLimit(t *testing.T) {
 	}
 }
 
+func TestClient_GetChannelInfo_StopsRetryingPersistentRateLimit(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	_, err := c.GetChannelInfo("C123456")
+
+	if err == nil || !strings.Contains(err.Error(), "rate limit retries exhausted after 3 retries") {
+		t.Fatalf("expected exhausted retry error, got %v", err)
+	}
+	if requests != 4 {
+		t.Fatalf("expected 4 requests, got %d", requests)
+	}
+}
+
 func TestClient_ListChannels_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -105,6 +105,33 @@ func TestClient_GetChannelInfo_APIError(t *testing.T) {
 	}
 }
 
+func TestClient_GetChannelInfo_RetriesRateLimit(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":      true,
+			"channel": map[string]interface{}{"id": "C123456"},
+		})
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	_, err := c.GetChannelInfo("C123456")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+}
+
 func TestClient_ListChannels_Success(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewWithConfig(t *testing.T) {
@@ -108,9 +109,12 @@ func TestClient_GetChannelInfo_APIError(t *testing.T) {
 func TestClient_GetChannelInfo_RetriesRateLimit(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/conversations.info" {
+			t.Errorf("expected /conversations.info, got %s", r.URL.Path)
+		}
 		requests++
 		if requests == 1 {
-			w.Header().Set("Retry-After", "0")
+			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -122,13 +126,18 @@ func TestClient_GetChannelInfo_RetriesRateLimit(t *testing.T) {
 	defer server.Close()
 
 	c := NewWithConfig(server.URL, "test-token", nil)
+	started := time.Now()
 	_, err := c.GetChannelInfo("C123456")
+	elapsed := time.Since(started)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if requests != 2 {
 		t.Fatalf("expected 2 requests, got %d", requests)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 3*time.Second {
+		t.Fatalf("expected retry after about 1 second, took %s", elapsed)
 	}
 }
 
@@ -217,6 +226,50 @@ func TestClient_ListChannels_Pagination(t *testing.T) {
 	}
 	if len(channels) != 2 {
 		t.Errorf("expected 2 channels total, got %d", len(channels))
+	}
+}
+
+func TestClient_ListUserConversations_Pagination(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/users.conversations" {
+			t.Errorf("expected /users.conversations, got %s", r.URL.Path)
+		}
+		requests++
+		if requests == 1 {
+			if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+				t.Errorf("expected no cursor on first request, got %s", cursor)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":                true,
+				"channels":          []map[string]interface{}{{"id": "C1"}},
+				"response_metadata": map[string]string{"next_cursor": "next-page"},
+			})
+			return
+		}
+
+		if cursor := r.URL.Query().Get("cursor"); cursor != "next-page" {
+			t.Errorf("expected cursor=next-page, got %s", cursor)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":                true,
+			"channels":          []map[string]interface{}{{"id": "D1"}},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		})
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	conversations, err := c.ListUserConversations()
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("expected 2 API calls for pagination, got %d", requests)
+	}
+	if len(conversations) != 2 || conversations[0].ID != "C1" || conversations[1].ID != "D1" {
+		t.Fatalf("expected both pages in order, got %+v", conversations)
 	}
 }
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/messages"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/search"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/setcred"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/unreads"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/users"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/workspace"
 	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
@@ -140,6 +141,7 @@ func init() {
 	rootCmd.AddCommand(canvas.NewCmd())
 	rootCmd.AddCommand(channels.NewCmd())
 	rootCmd.AddCommand(users.NewCmd())
+	rootCmd.AddCommand(unreads.NewCmd())
 	rootCmd.AddCommand(messages.NewCmd())
 	rootCmd.AddCommand(search.NewCmd())
 	rootCmd.AddCommand(workspace.NewCmd())

--- a/internal/cmd/unreads/unreads.go
+++ b/internal/cmd/unreads/unreads.go
@@ -77,9 +77,6 @@ func runList(opts *listOptions, c *client.Client) error {
 		isApp := conversation.IsIM && isApp(users[conversation.User])
 		switch {
 		case conversation.IsIM || conversation.IsMpIM:
-			if conversation.Priority <= 0 {
-				continue
-			}
 			if (isApp && !opts.includeApps) || (!isApp && opts.excludeDMs) {
 				continue
 			}

--- a/internal/cmd/unreads/unreads.go
+++ b/internal/cmd/unreads/unreads.go
@@ -43,7 +43,7 @@ func newListCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&opts.excludeChannels, "exclude-channels", false, "Exclude channels")
 	cmd.Flags().BoolVar(&opts.excludeDMs, "exclude-dms", false, "Exclude direct messages")
-	cmd.Flags().BoolVar(&opts.includeApps, "include-apps", false, "Include direct messages with agents and apps")
+	cmd.Flags().BoolVar(&opts.includeApps, "include-apps", false, "Include agent and app DMs even when --exclude-dms is set")
 	return cmd
 }
 

--- a/internal/cmd/unreads/unreads.go
+++ b/internal/cmd/unreads/unreads.go
@@ -1,0 +1,172 @@
+package unreads
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+type listOptions struct {
+	excludeChannels bool
+	excludeDMs      bool
+	includeApps     bool
+}
+
+type unreadConversation struct {
+	id   string
+	name string
+}
+
+// NewCmd creates the unreads command.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unreads",
+		Short: "List unread conversations (requires user token)",
+	}
+	cmd.AddCommand(newListCmd())
+	return cmd
+}
+
+func newListCmd() *cobra.Command {
+	opts := &listOptions{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List unread channels and direct messages",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(opts, nil)
+		},
+	}
+	cmd.Flags().BoolVar(&opts.excludeChannels, "exclude-channels", false, "Exclude channels")
+	cmd.Flags().BoolVar(&opts.excludeDMs, "exclude-dms", false, "Exclude direct messages")
+	cmd.Flags().BoolVar(&opts.includeApps, "include-apps", false, "Include direct messages with agents and apps")
+	return cmd
+}
+
+func runList(opts *listOptions, c *client.Client) error {
+	if c == nil {
+		var err error
+		c, err = client.NewUserClient()
+		if err != nil {
+			return err
+		}
+	}
+
+	conversations, err := c.ListUserConversations()
+	if err != nil {
+		return err
+	}
+
+	users := map[string]client.User{}
+	if !opts.excludeDMs || opts.includeApps {
+		allUsers, err := c.ListAllUsers()
+		if err != nil {
+			return err
+		}
+		for _, user := range allUsers {
+			users[user.ID] = user
+		}
+	}
+
+	var channels, dms, apps []unreadConversation
+	for _, conversation := range conversations {
+		isApp := conversation.IsIM && isApp(users[conversation.User])
+		switch {
+		case conversation.IsIM || conversation.IsMpIM:
+			if conversation.Priority <= 0 {
+				continue
+			}
+			if (isApp && !opts.includeApps) || (!isApp && opts.excludeDMs) {
+				continue
+			}
+		case opts.excludeChannels:
+			continue
+		}
+
+		unread, err := isUnread(c, conversation.ID)
+		if err != nil {
+			return err
+		}
+		if !unread {
+			continue
+		}
+
+		item := unreadConversation{id: conversation.ID, name: conversationName(conversation, users)}
+		switch {
+		case isApp:
+			apps = append(apps, item)
+		case conversation.IsIM || conversation.IsMpIM:
+			dms = append(dms, item)
+		default:
+			channels = append(channels, item)
+		}
+	}
+
+	if len(channels)+len(dms)+len(apps) == 0 {
+		output.Println("No unread conversations")
+		return nil
+	}
+	render("Channels", channels)
+	render("Direct messages", dms)
+	render("Agents & apps", apps)
+	return nil
+}
+
+func isUnread(c *client.Client, conversationID string) (bool, error) {
+	info, err := c.GetChannelInfo(conversationID)
+	if err != nil {
+		return false, fmt.Errorf("check unread status for %s: %w", conversationID, err)
+	}
+	if info.UnreadCount != nil {
+		return *info.UnreadCount > 0, nil
+	}
+
+	oldest := info.LastRead
+	if strings.Trim(oldest, "0.") == "" {
+		oldest = ""
+	}
+	messages, err := c.GetChannelHistory(conversationID, 1, oldest, "")
+	if err != nil {
+		return false, fmt.Errorf("check unread status for %s: %w", conversationID, err)
+	}
+	return len(messages) > 0, nil
+}
+
+func isApp(user client.User) bool {
+	return user.IsBot || user.IsAppUser || user.ID == "USLACKBOT"
+}
+
+func conversationName(conversation client.Channel, users map[string]client.User) string {
+	if !conversation.IsIM {
+		return conversation.Name
+	}
+	user, ok := users[conversation.User]
+	if !ok {
+		return conversation.User
+	}
+	if user.Profile.DisplayName != "" {
+		return user.Profile.DisplayName
+	}
+	if user.RealName != "" {
+		return user.RealName
+	}
+	return user.Name
+}
+
+func render(title string, conversations []unreadConversation) {
+	if len(conversations) == 0 {
+		return
+	}
+	sort.Slice(conversations, func(i, j int) bool { return conversations[i].name < conversations[j].name })
+	output.Println(title)
+	rows := make([][]string, 0, len(conversations))
+	for _, conversation := range conversations {
+		rows = append(rows, []string{conversation.id, conversation.name})
+	}
+	output.Table([]string{"ID", "NAME"}, rows)
+	output.Println()
+}

--- a/internal/cmd/unreads/unreads_test.go
+++ b/internal/cmd/unreads/unreads_test.go
@@ -25,10 +25,10 @@ func TestRunListGroupsUnreadConversations(t *testing.T) {
 				"channels": []map[string]any{
 					{"id": "C1", "name": "alerts"},
 					{"id": "C2", "name": "general"},
-					{"id": "D1", "is_im": true, "user": "U1", "priority": 0.2},
-					{"id": "D2", "is_im": true, "user": "B1", "priority": 0.1},
-					{"id": "D3", "is_im": true, "user": "U1", "priority": 0},
-					{"id": "G1", "name": "project", "is_mpim": true, "priority": 0.05},
+					{"id": "D1", "is_im": true, "user": "U1", "priority": 0},
+					{"id": "D2", "is_im": true, "user": "B1"},
+					{"id": "D3", "is_im": true, "user": "U1"},
+					{"id": "G1", "name": "project", "is_mpim": true, "priority": 0},
 				},
 			}
 		case "/users.list":
@@ -41,7 +41,6 @@ func TestRunListGroupsUnreadConversations(t *testing.T) {
 			}
 		case "/conversations.info":
 			id := r.URL.Query().Get("channel")
-			assert.NotEqual(t, "D3", id, "dormant DMs should not be scanned")
 			channel := map[string]any{"id": id, "last_read": "1.000000"}
 			switch id {
 			case "D1":
@@ -82,7 +81,9 @@ func TestRunListGroupsUnreadConversations(t *testing.T) {
 	assert.Contains(t, buf.String(), "C1")
 	assert.NotContains(t, buf.String(), "C2")
 	assert.Contains(t, buf.String(), "Direct messages")
+	assert.Contains(t, buf.String(), "D1")
 	assert.Contains(t, buf.String(), "Alice")
+	assert.Contains(t, buf.String(), "G1")
 	assert.Contains(t, buf.String(), "project")
 	assert.NotContains(t, buf.String(), "Agents & apps")
 	assert.NotContains(t, buf.String(), "helper")
@@ -136,9 +137,9 @@ func TestRunListExclusions(t *testing.T) {
 						"ok": true,
 						"channels": []map[string]any{
 							{"id": "C1", "name": "channel"},
-							{"id": "D1", "is_im": true, "user": "U1", "priority": 1},
-							{"id": "D2", "is_im": true, "user": "B1", "priority": 1},
-							{"id": "G1", "name": "group", "is_mpim": true, "priority": 1},
+							{"id": "D1", "is_im": true, "user": "U1"},
+							{"id": "D2", "is_im": true, "user": "B1"},
+							{"id": "G1", "name": "group", "is_mpim": true},
 						},
 					}
 				case "/users.list":

--- a/internal/cmd/unreads/unreads_test.go
+++ b/internal/cmd/unreads/unreads_test.go
@@ -93,3 +93,89 @@ func TestRunListGroupsUnreadConversations(t *testing.T) {
 	assert.Contains(t, buf.String(), "D2")
 	assert.Contains(t, buf.String(), "helper")
 }
+
+func TestRunListExclusions(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        listOptions
+		wantScanned []string
+		wantOutput  []string
+		notOutput   []string
+	}{
+		{
+			name:        "channels",
+			opts:        listOptions{excludeChannels: true},
+			wantScanned: []string{"D1", "G1"},
+			wantOutput:  []string{"D1", "G1"},
+			notOutput:   []string{"C1", "D2"},
+		},
+		{
+			name:        "direct messages",
+			opts:        listOptions{excludeDMs: true},
+			wantScanned: []string{"C1"},
+			wantOutput:  []string{"C1"},
+			notOutput:   []string{"D1", "D2", "G1"},
+		},
+		{
+			name:        "direct messages with apps included",
+			opts:        listOptions{excludeDMs: true, includeApps: true},
+			wantScanned: []string{"C1", "D2"},
+			wantOutput:  []string{"C1", "D2"},
+			notOutput:   []string{"D1", "G1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var scanned []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var response any
+				switch r.URL.Path {
+				case "/users.conversations":
+					response = map[string]any{
+						"ok": true,
+						"channels": []map[string]any{
+							{"id": "C1", "name": "channel"},
+							{"id": "D1", "is_im": true, "user": "U1", "priority": 1},
+							{"id": "D2", "is_im": true, "user": "B1", "priority": 1},
+							{"id": "G1", "name": "group", "is_mpim": true, "priority": 1},
+						},
+					}
+				case "/users.list":
+					response = map[string]any{
+						"ok": true,
+						"members": []map[string]any{
+							{"id": "U1", "name": "human"},
+							{"id": "B1", "name": "app", "is_app_user": true},
+						},
+					}
+				case "/conversations.info":
+					id := r.URL.Query().Get("channel")
+					scanned = append(scanned, id)
+					response = map[string]any{
+						"ok":      true,
+						"channel": map[string]any{"id": id, "unread_count": 1},
+					}
+				default:
+					t.Fatalf("unexpected request: %s", r.URL.String())
+				}
+				assert.NoError(t, json.NewEncoder(w).Encode(response))
+			}))
+			defer server.Close()
+
+			originalWriter := output.Writer
+			defer func() { output.Writer = originalWriter }()
+			var buf bytes.Buffer
+			output.Writer = &buf
+
+			require.NoError(t, runList(&tt.opts, client.NewWithConfig(server.URL, "xoxp-test", nil)))
+			assert.ElementsMatch(t, tt.wantScanned, scanned)
+			for _, value := range tt.wantOutput {
+				assert.Contains(t, buf.String(), value)
+			}
+			for _, value := range tt.notOutput {
+				assert.NotContains(t, buf.String(), value)
+			}
+		})
+	}
+}

--- a/internal/cmd/unreads/unreads_test.go
+++ b/internal/cmd/unreads/unreads_test.go
@@ -1,0 +1,95 @@
+package unreads
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+func TestRunListGroupsUnreadConversations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var response any
+		switch r.URL.Path {
+		case "/users.conversations":
+			assert.Equal(t, "public_channel,private_channel,im,mpim", r.URL.Query().Get("types"))
+			response = map[string]any{
+				"ok": true,
+				"channels": []map[string]any{
+					{"id": "C1", "name": "alerts"},
+					{"id": "C2", "name": "general"},
+					{"id": "D1", "is_im": true, "user": "U1", "priority": 0.2},
+					{"id": "D2", "is_im": true, "user": "B1", "priority": 0.1},
+					{"id": "D3", "is_im": true, "user": "U1", "priority": 0},
+					{"id": "G1", "name": "project", "is_mpim": true, "priority": 0.05},
+				},
+			}
+		case "/users.list":
+			response = map[string]any{
+				"ok": true,
+				"members": []map[string]any{
+					{"id": "U1", "name": "alice", "profile": map[string]any{"display_name": "Alice"}},
+					{"id": "B1", "name": "helper", "is_app_user": true},
+				},
+			}
+		case "/conversations.info":
+			id := r.URL.Query().Get("channel")
+			assert.NotEqual(t, "D3", id, "dormant DMs should not be scanned")
+			channel := map[string]any{"id": id, "last_read": "1.000000"}
+			switch id {
+			case "D1":
+				channel["unread_count"] = 2
+			case "D2":
+				channel["unread_count"] = 1
+			case "G1":
+				channel["last_read"] = "0"
+			}
+			response = map[string]any{"ok": true, "channel": channel}
+		case "/conversations.history":
+			assert.Equal(t, "1", r.URL.Query().Get("limit"))
+			if r.URL.Query().Get("channel") == "G1" {
+				assert.Empty(t, r.URL.Query().Get("oldest"))
+			} else {
+				assert.Equal(t, "1.000000", r.URL.Query().Get("oldest"))
+			}
+			messages := []map[string]any{}
+			if id := r.URL.Query().Get("channel"); id == "C1" || id == "G1" {
+				messages = append(messages, map[string]any{"ts": "2.000000", "text": "new"})
+			}
+			response = map[string]any{"ok": true, "messages": messages}
+		default:
+			t.Fatalf("unexpected request: %s", r.URL.String())
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "xoxp-test", nil)
+	originalWriter := output.Writer
+	defer func() { output.Writer = originalWriter }()
+
+	var buf bytes.Buffer
+	output.Writer = &buf
+	require.NoError(t, runList(&listOptions{}, c))
+	assert.Contains(t, buf.String(), "Channels")
+	assert.Contains(t, buf.String(), "C1")
+	assert.NotContains(t, buf.String(), "C2")
+	assert.Contains(t, buf.String(), "Direct messages")
+	assert.Contains(t, buf.String(), "Alice")
+	assert.Contains(t, buf.String(), "project")
+	assert.NotContains(t, buf.String(), "Agents & apps")
+	assert.NotContains(t, buf.String(), "helper")
+
+	buf.Reset()
+	require.NoError(t, runList(&listOptions{includeApps: true}, c))
+	assert.Contains(t, buf.String(), "Agents & apps")
+	assert.Contains(t, buf.String(), "D2")
+	assert.Contains(t, buf.String(), "helper")
+}

--- a/slack-app-manifest.yaml
+++ b/slack-app-manifest.yaml
@@ -23,7 +23,16 @@ oauth_config:
       - team:read
       - users:read
     user:
+      - channels:history
+      - channels:read
+      - groups:history
+      - groups:read
+      - im:history
+      - im:read
+      - mpim:history
+      - mpim:read
       - search:read
+      - users:read
 
 settings:
   org_deploy_enabled: false


### PR DESCRIPTION
## [INT-850]

Closes #199

## Summary

- add a supported user-token command for listing unread channels and direct messages
- separate agent and app DMs behind --include-apps
- honor Slack Retry-After responses and document the required scopes and API limitations

## Test plan

- go test -race ./...
- make lint
- live slck unreads list --exclude-dms smoke test