### PR TITLE
build: sign local darwin builds when CODESIGN_IDENTITY is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,17 @@ export GOFLAGS := -tags=keyring_no1password,keyring_nopassage
 
 all: build
 
+# macOS code-signing for local builds: a stable designated requirement so the
+# Keychain "Always Allow" grant survives a rebuild (cli-common distribution.md
+# §2A). Identifier scheme and flags mirror open-cli-collective/.github
+# macos-codesign-setup/codesign-darwin.sh, which signs releases. CODESIGN_IDENTITY
+# unset (the CI/Linux default) is a no-op.
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/slck
+	@if [ -n "$(CODESIGN_IDENTITY)" ] && [ "$$(uname -s)" = Darwin ] && [ "$$(go env GOOS)" = darwin ]; then \
+		codesign --force --timestamp=none --sign "$(CODESIGN_IDENTITY)" --identifier "org.open-cli-collective.$(BINARY)" bin/$(BINARY) && \
+		codesign --verify --strict -R '=identifier "org.open-cli-collective.$(BINARY)"' bin/$(BINARY); \
+	fi
 	@if [ -n "$(CODESIGN_IDENTITY)" ] && [ "$$(uname -s)" = Darwin ]; then \
 		codesign --force --timestamp=none --sign "$(CODESIGN_IDENTITY)" --identifier "org.open-cli-collective.$(BINARY)" bin/$(BINARY); \
 		codesign --verify --strict bin/$(BINARY); \

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ all: build
 
 build:
 	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/slck
+	@if [ -n "$(CODESIGN_IDENTITY)" ] && [ "$$(uname -s)" = Darwin ]; then \
+		codesign --force --timestamp=none --sign "$(CODESIGN_IDENTITY)" --identifier "org.open-cli-collective.$(BINARY)" bin/$(BINARY); \
+		codesign --verify --strict bin/$(BINARY); \
+	fi
 
 test:
 	go test -v -race ./...

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ build:
 		codesign --force --timestamp=none --sign "$(CODESIGN_IDENTITY)" --identifier "org.open-cli-collective.$(BINARY)" bin/$(BINARY) && \
 		codesign --verify --strict -R '=identifier "org.open-cli-collective.$(BINARY)"' bin/$(BINARY); \
 	fi
-	@if [ -n "$(CODESIGN_IDENTITY)" ] && [ "$$(uname -s)" = Darwin ]; then \
-		codesign --force --timestamp=none --sign "$(CODESIGN_IDENTITY)" --identifier "org.open-cli-collective.$(BINARY)" bin/$(BINARY); \
-		codesign --verify --strict bin/$(BINARY); \
-	fi
 
 test:
 	go test -v -race ./...

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,8 @@ make clean      # remove build artifacts
 make install    # install to /usr/local/bin
 ```
 
+On macOS, set `CODESIGN_IDENTITY` to a code-signing certificate in your login keychain (name or SHA-1) and `make build` re-signs `bin/slck` with a stable designated requirement, so Keychain asks for "Always Allow" once per credential instead of once per rebuild. Unset (the default, and on CI/Linux) the build is unchanged.
+
 ## Repo Structure
 
 ```text


### PR DESCRIPTION
Release binaries are signed in CI with the org's stable identity so macOS Keychain "Always Allow" grants survive upgrades. Local `make build` output was still ad-hoc signed, so every rebuild carried a fresh `cdhash` designated requirement and Keychain re-prompted once per stored credential.

This adds the same gated step to the Makefile build targets: when `CODESIGN_IDENTITY` is set on Darwin, the binary is re-signed with that identity and the `org.open-cli-collective.<tool>` identifier, matching the CI signing script. Unset (the default, and on CI/Linux) the build is unchanged.

A developer can point the variable at any self-signed code-signing cert in their login keychain. One "Always Allow" per credential then covers every subsequent local build.

Verified locally: with the variable set, `codesign -d -r-` reports `identifier "org.open-cli-collective.<tool>" and certificate leaf = H"…"`; with it unset the designated requirement is the previous per-build `cdhash`.
